### PR TITLE
flasher: catch NotADirectory exception

### DIFF
--- a/lib/flasher.py
+++ b/lib/flasher.py
@@ -64,7 +64,7 @@ class Flasher:
                 # flash
                 qprint("flashing ...", cmd)
                 self._esptool(cmd)
-        except PermissionError:
+        except (PermissionError, NotADirectoryError):
             # Windows throws error
             pass
 


### PR DESCRIPTION
in py38, when tearing down the temporary directory, NotADirectory
Exception will be thrown. Not catching that causes problem.